### PR TITLE
dts: xiaomi: msm8992: Mount cust partition as /vendor

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8992.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8992.dtsi
@@ -32,6 +32,14 @@
 			compatible = "android,firmware";
 			fstab {
 				compatible = "android,fstab";
+				vendor {
+					compatible = "android,vendor";
+					dev = "/dev/block/platform/soc.0/f9824900.sdhci/by-name/cust";
+					type = "ext4";
+					mnt_flags = "ro,barrier=1,discard";
+					fsmgr_flags = "wait";
+					status = "ok";
+				};
 				system {
 					compatible = "android,system";
 					dev = "/dev/block/platform/soc.0/f9824900.sdhci/by-name/system";


### PR DESCRIPTION
Change-Id: I0d27e50456897a0c25336e18f2652af01aa131e9